### PR TITLE
Add Go API and React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ profile.cov
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+node_modules/
+frontend/node_modules/
 
 # Go workspace file
 go.work

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module fullstack-go-api/backend
+
+go 1.24.3

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// HashPassword hashes plaintext password with SHA-256.
+func HashPassword(password string) string {
+	digest := sha256.Sum256([]byte(password))
+	return hex.EncodeToString(digest[:])
+}
+
+// ComparePassword compares plaintext password with stored hash.
+func ComparePassword(hash, password string) bool {
+	return hash == HashPassword(password)
+}
+
+type tokenPayload struct {
+	Subject   string   `json:"sub"`
+	ExpiresAt int64    `json:"exp"`
+	IssuedAt  int64    `json:"iat"`
+	Issuer    string   `json:"iss"`
+	Audience  []string `json:"aud"`
+	UserID    int      `json:"userId"`
+}
+
+// GenerateToken creates a JWT signed with the provided secret using HS256.
+func GenerateToken(userID int, email, secret string, ttl time.Duration) (string, error) {
+	header := map[string]string{
+		"alg": "HS256",
+		"typ": "JWT",
+	}
+
+	payload := tokenPayload{
+		Subject:   email,
+		ExpiresAt: time.Now().Add(ttl).Unix(),
+		IssuedAt:  time.Now().Unix(),
+		Issuer:    "fullstack-go-api",
+		Audience:  []string{"fullstack-go-api"},
+		UserID:    userID,
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	headerPart := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadPart := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := headerPart + "." + payloadPart
+
+	signature := sign(signingInput, secret)
+	return signingInput + "." + signature, nil
+}
+
+// ParseToken validates the provided JWT and returns the user id and email.
+func ParseToken(tokenString, secret string) (int, string, error) {
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return 0, "", errors.New("invalid token format")
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+	expectedSig := sign(signingInput, secret)
+	if !secureCompare(expectedSig, parts[2]) {
+		return 0, "", errors.New("invalid token signature")
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return 0, "", errors.New("invalid token payload")
+	}
+
+	var payload tokenPayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return 0, "", errors.New("invalid token payload")
+	}
+
+	if payload.ExpiresAt < time.Now().Unix() {
+		return 0, "", errors.New("token expired")
+	}
+
+	if payload.Subject == "" || payload.UserID == 0 {
+		return 0, "", errors.New("invalid token claims")
+	}
+
+	return payload.UserID, payload.Subject, nil
+}
+
+func sign(data, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(data))
+	signature := mac.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func secureCompare(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	var result byte
+	for i := 0; i < len(a); i++ {
+		result |= a[i] ^ b[i]
+	}
+	return result == 0
+}

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -1,0 +1,337 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"fullstack-go-api/backend/internal/auth"
+	"fullstack-go-api/backend/internal/models"
+	"fullstack-go-api/backend/internal/store"
+)
+
+type contextKey string
+
+const userContextKey contextKey = "user"
+
+// Handler bundles dependencies for HTTP handlers.
+type Handler struct {
+	Store     *store.Store
+	JWTSecret string
+	TokenTTL  time.Duration
+}
+
+// New creates a Handler with sane defaults.
+func New(store *store.Store) *Handler {
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		secret = "supersecretkey"
+	}
+	return &Handler{Store: store, JWTSecret: secret, TokenTTL: 24 * time.Hour}
+}
+
+// WriteJSON serializes payload into JSON response.
+func WriteJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if payload == nil {
+		return
+	}
+	encoder := json.NewEncoder(w)
+	_ = encoder.Encode(payload)
+}
+
+func errorResponse(w http.ResponseWriter, status int, message string) {
+	WriteJSON(w, status, map[string]string{"error": message})
+}
+
+type registerRequest struct {
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type updateRequest struct {
+	Name     *string `json:"name"`
+	Email    *string `json:"email"`
+	Password *string `json:"password"`
+}
+
+// Register handles user creation.
+func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req registerRequest
+	if err := decodeJSON(r, &req); err != nil {
+		errorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	name := strings.TrimSpace(req.Name)
+	email := strings.TrimSpace(req.Email)
+	password := req.Password
+
+	if name == "" || email == "" || password == "" {
+		errorResponse(w, http.StatusBadRequest, "name, email, and password are required")
+		return
+	}
+
+	if !strings.Contains(email, "@") {
+		errorResponse(w, http.StatusBadRequest, "email must be valid")
+		return
+	}
+
+	if len(password) < 6 {
+		errorResponse(w, http.StatusBadRequest, "password must be at least 6 characters")
+		return
+	}
+
+	hashed := auth.HashPassword(password)
+	user := models.User{
+		Name:         name,
+		Email:        email,
+		PasswordHash: hashed,
+	}
+
+	created, err := h.Store.CreateUser(user)
+	if err != nil {
+		if errors.Is(err, store.ErrEmailExists) {
+			errorResponse(w, http.StatusConflict, "email already registered")
+			return
+		}
+		errorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	token, err := auth.GenerateToken(created.ID, created.Email, h.JWTSecret, h.TokenTTL)
+	if err != nil {
+		errorResponse(w, http.StatusInternalServerError, "failed to create token")
+		return
+	}
+
+	WriteJSON(w, http.StatusCreated, map[string]interface{}{
+		"user":  created.Sanitized(),
+		"token": token,
+	})
+}
+
+// Login handles user authentication.
+func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req loginRequest
+	if err := decodeJSON(r, &req); err != nil {
+		errorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	email := strings.TrimSpace(req.Email)
+	password := req.Password
+
+	if email == "" || password == "" {
+		errorResponse(w, http.StatusBadRequest, "email and password are required")
+		return
+	}
+
+	user, err := h.Store.GetUserByEmail(email)
+	if err != nil || !auth.ComparePassword(user.PasswordHash, password) {
+		errorResponse(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	token, err := auth.GenerateToken(user.ID, user.Email, h.JWTSecret, h.TokenTTL)
+	if err != nil {
+		errorResponse(w, http.StatusInternalServerError, "failed to create token")
+		return
+	}
+
+	WriteJSON(w, http.StatusOK, map[string]interface{}{
+		"user":  user.Sanitized(),
+		"token": token,
+	})
+}
+
+// UsersCollection handles requests to /api/users.
+func (h *Handler) UsersCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	users := h.Store.ListUsers()
+	sanitized := make([]models.User, 0, len(users))
+	for _, user := range users {
+		sanitized = append(sanitized, user.Sanitized())
+	}
+
+	WriteJSON(w, http.StatusOK, map[string]interface{}{"users": sanitized})
+}
+
+// UserResource handles requests to /api/users/{id}.
+func (h *Handler) UserResource(w http.ResponseWriter, r *http.Request) {
+	idStr := strings.TrimPrefix(r.URL.Path, "/api/users/")
+	if idStr == "" {
+		errorResponse(w, http.StatusNotFound, "user not found")
+		return
+	}
+
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		errorResponse(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		user, err := h.Store.GetUser(id)
+		if err != nil {
+			errorResponse(w, http.StatusNotFound, "user not found")
+			return
+		}
+		WriteJSON(w, http.StatusOK, map[string]interface{}{"user": user.Sanitized()})
+	case http.MethodPut:
+		var req updateRequest
+		if err := decodeJSON(r, &req); err != nil {
+			errorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if req.Name != nil {
+			trimmed := strings.TrimSpace(*req.Name)
+			if trimmed == "" {
+				errorResponse(w, http.StatusBadRequest, "name cannot be empty")
+				return
+			}
+			req.Name = &trimmed
+		}
+		if req.Email != nil {
+			trimmedEmail := strings.TrimSpace(*req.Email)
+			if trimmedEmail == "" || !strings.Contains(trimmedEmail, "@") {
+				errorResponse(w, http.StatusBadRequest, "email must be valid")
+				return
+			}
+			req.Email = &trimmedEmail
+		}
+		if req.Password != nil && *req.Password != "" && len(*req.Password) < 6 {
+			errorResponse(w, http.StatusBadRequest, "password must be at least 6 characters")
+			return
+		}
+
+		updated, err := h.Store.UpdateUser(id, func(existing models.User) (models.User, error) {
+			if req.Name != nil {
+				existing.Name = *req.Name
+			}
+			if req.Email != nil {
+				existing.Email = *req.Email
+			}
+			if req.Password != nil && *req.Password != "" {
+				existing.PasswordHash = auth.HashPassword(*req.Password)
+			}
+			return existing, nil
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrUserNotFound):
+				errorResponse(w, http.StatusNotFound, "user not found")
+			case errors.Is(err, store.ErrEmailExists):
+				errorResponse(w, http.StatusConflict, "email already registered")
+			default:
+				errorResponse(w, http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		WriteJSON(w, http.StatusOK, map[string]interface{}{"user": updated.Sanitized()})
+	case http.MethodDelete:
+		if err := h.Store.DeleteUser(id); err != nil {
+			errorResponse(w, http.StatusNotFound, "user not found")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.Header().Set("Allow", strings.Join([]string{http.MethodGet, http.MethodPut, http.MethodDelete}, ", "))
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// Profile returns the authenticated user's details.
+func (h *Handler) Profile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	user, ok := GetUserFromContext(r.Context())
+	if !ok {
+		errorResponse(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	WriteJSON(w, http.StatusOK, map[string]interface{}{"user": user.Sanitized()})
+}
+
+// WithAuth ensures a request is authenticated before invoking the handler.
+func (h *Handler) WithAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			errorResponse(w, http.StatusUnauthorized, "missing authorization header")
+			return
+		}
+
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+			errorResponse(w, http.StatusUnauthorized, "invalid authorization header")
+			return
+		}
+
+		userID, email, err := auth.ParseToken(parts[1], h.JWTSecret)
+		if err != nil {
+			errorResponse(w, http.StatusUnauthorized, "invalid token")
+			return
+		}
+
+		user, err := h.Store.GetUser(userID)
+		if err != nil || !strings.EqualFold(user.Email, email) {
+			errorResponse(w, http.StatusUnauthorized, "invalid token")
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), userContextKey, user)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetUserFromContext retrieves the authenticated user from the context.
+func GetUserFromContext(ctx context.Context) (models.User, bool) {
+	user, ok := ctx.Value(userContextKey).(models.User)
+	return user, ok
+}
+
+func decodeJSON(r *http.Request, v interface{}) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -1,0 +1,19 @@
+package models
+
+import "time"
+
+// User represents an account that can authenticate with the API.
+type User struct {
+	ID           int       `json:"id"`
+	Name         string    `json:"name"`
+	Email        string    `json:"email"`
+	PasswordHash string    `json:"-"`
+	CreatedAt    time.Time `json:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt"`
+}
+
+// Sanitized returns a copy of the user safe for serialization.
+func (u User) Sanitized() User {
+	u.PasswordHash = ""
+	return u
+}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -1,0 +1,138 @@
+package store
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"fullstack-go-api/backend/internal/models"
+)
+
+// ErrUserNotFound indicates requested user does not exist.
+var ErrUserNotFound = errors.New("user not found")
+
+// ErrEmailExists indicates email already registered.
+var ErrEmailExists = errors.New("email already registered")
+
+// Store provides in-memory persistence for users.
+type Store struct {
+	mu     sync.RWMutex
+	users  map[int]models.User
+	byMail map[string]int
+	nextID int
+}
+
+// New returns a new Store.
+func New() *Store {
+	return &Store{
+		users:  make(map[int]models.User),
+		byMail: make(map[string]int),
+		nextID: 1,
+	}
+}
+
+// CreateUser saves a new user and returns it.
+func (s *Store) CreateUser(user models.User) (models.User, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := strings.ToLower(user.Email)
+	if _, exists := s.byMail[key]; exists {
+		return models.User{}, ErrEmailExists
+	}
+
+	now := time.Now().UTC()
+	user.ID = s.nextID
+	user.CreatedAt = now
+	user.UpdatedAt = now
+
+	s.users[user.ID] = user
+	s.byMail[key] = user.ID
+	s.nextID++
+
+	return user, nil
+}
+
+// UpdateUser updates an existing user by id.
+func (s *Store) UpdateUser(id int, fn func(models.User) (models.User, error)) (models.User, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	user, ok := s.users[id]
+	if !ok {
+		return models.User{}, ErrUserNotFound
+	}
+
+	updated, err := fn(user)
+	if err != nil {
+		return models.User{}, err
+	}
+
+	if !strings.EqualFold(user.Email, updated.Email) {
+		// ensure new email unique
+		newKey := strings.ToLower(updated.Email)
+		if existingID, exists := s.byMail[newKey]; exists && existingID != user.ID {
+			return models.User{}, ErrEmailExists
+		}
+		delete(s.byMail, strings.ToLower(user.Email))
+		s.byMail[newKey] = user.ID
+	}
+
+	updated.ID = user.ID
+	updated.CreatedAt = user.CreatedAt
+	updated.UpdatedAt = time.Now().UTC()
+	s.users[id] = updated
+	return updated, nil
+}
+
+// GetUser fetches a user by id.
+func (s *Store) GetUser(id int) (models.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	user, ok := s.users[id]
+	if !ok {
+		return models.User{}, ErrUserNotFound
+	}
+	return user, nil
+}
+
+// GetUserByEmail returns user by email.
+func (s *Store) GetUserByEmail(email string) (models.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	id, ok := s.byMail[strings.ToLower(email)]
+	if !ok {
+		return models.User{}, ErrUserNotFound
+	}
+	return s.users[id], nil
+}
+
+// ListUsers returns all stored users.
+func (s *Store) ListUsers() []models.User {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]models.User, 0, len(s.users))
+	for _, user := range s.users {
+		result = append(result, user)
+	}
+	return result
+}
+
+// DeleteUser removes a user by id.
+func (s *Store) DeleteUser(id int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	user, ok := s.users[id]
+	if !ok {
+		return ErrUserNotFound
+	}
+
+	delete(s.users, id)
+	delete(s.byMail, strings.ToLower(user.Email))
+	return nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	handler := SetupRouter()
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	server := &http.Server{
+		Addr:    ":" + port,
+		Handler: handler,
+	}
+
+	log.Printf("server listening on %s", server.Addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("failed to run server: %v", err)
+	}
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/http"
+
+	"fullstack-go-api/backend/internal/handlers"
+	"fullstack-go-api/backend/internal/store"
+)
+
+// SetupRouter initializes the HTTP routes for the application.
+func SetupRouter() http.Handler {
+	store := store.New()
+	handler := handlers.New(store)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/register", handler.Register)
+	mux.HandleFunc("/api/login", handler.Login)
+
+	mux.Handle("/api/profile", handler.WithAuth(http.HandlerFunc(handler.Profile)))
+	mux.Handle("/api/users", handler.WithAuth(http.HandlerFunc(handler.UsersCollection)))
+	mux.Handle("/api/users/", handler.WithAuth(http.HandlerFunc(handler.UserResource)))
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	return mux
+}
+
+func respondJSON(w http.ResponseWriter, status int, payload interface{}) {
+	handlers.WriteJSON(w, status, payload)
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fullstack Go App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "fullstack-go-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@types/react-router-dom": "^5.3.3",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Link, Navigate, Route, Routes } from 'react-router-dom';
+import ProtectedRoute from './components/ProtectedRoute';
+import { useAuth } from './context/AuthContext';
+import DashboardPage from './pages/DashboardPage';
+import LoginPage from './pages/LoginPage';
+import ProfilePage from './pages/ProfilePage';
+import RegisterPage from './pages/RegisterPage';
+
+const App: React.FC = () => {
+  const { token, user, logout } = useAuth();
+
+  return (
+    <div className="app-container">
+      <header className="top-bar">
+        <Link to="/" className="brand">
+          Fullstack Go App
+        </Link>
+        <nav>
+          {token ? (
+            <>
+              <Link to="/dashboard">Dashboard</Link>
+              <Link to="/profile">Profile</Link>
+              <button type="button" onClick={logout} className="link-button">
+                Sign out
+              </button>
+              <span className="user-chip">{user?.email}</span>
+            </>
+          ) : (
+            <>
+              <Link to="/login">Login</Link>
+              <Link to="/register">Register</Link>
+            </>
+          )}
+        </nav>
+      </header>
+
+      <main className="content">
+        <Routes>
+          <Route path="/" element={<Navigate to={token ? '/dashboard' : '/login'} replace />} />
+          <Route path="/login" element={token ? <Navigate to="/dashboard" replace /> : <LoginPage />} />
+          <Route path="/register" element={token ? <Navigate to="/dashboard" replace /> : <RegisterPage />} />
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <DashboardPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/profile"
+            element={
+              <ProtectedRoute>
+                <ProfilePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,89 @@
+import type { AuthResponse, User } from './types';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api';
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    let message = 'Request failed';
+    try {
+      const data = await response.json();
+      if (data?.error) {
+        message = data.error;
+      }
+    } catch (error) {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function registerUser(payload: {
+  name: string;
+  email: string;
+  password: string;
+}): Promise<AuthResponse> {
+  return request<AuthResponse>('/register', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function loginUser(payload: { email: string; password: string }): Promise<AuthResponse> {
+  return request<AuthResponse>('/login', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function fetchProfile(token: string): Promise<{ user: User }> {
+  return request<{ user: User }>('/profile', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+export async function fetchUsers(token: string): Promise<{ users: User[] }> {
+  return request<{ users: User[] }>('/users', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+export async function updateUser(
+  token: string,
+  id: number,
+  payload: Partial<{ name: string; email: string; password: string }>,
+): Promise<{ user: User }> {
+  return request<{ user: User }>(`/users/${id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteUser(token: string, id: number): Promise<void> {
+  await request<void>(`/users/${id}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+interface ProtectedRouteProps {
+  children: React.ReactElement;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { token, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return <div className="centered">Loading...</div>;
+  }
+
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,132 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { fetchProfile, loginUser, registerUser } from '../api';
+import type { AuthResponse, User } from '../types';
+
+interface AuthContextValue {
+  token: string | null;
+  user: User | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+  refreshProfile: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+const STORAGE_KEY = 'fullstack-go-token';
+
+function usePersistedToken(): [string | null, (token: string | null) => void] {
+  const [token, setTokenState] = useState<string | null>(() => localStorage.getItem(STORAGE_KEY));
+
+  const setToken = useCallback((value: string | null) => {
+    setTokenState(value);
+    if (value) {
+      localStorage.setItem(STORAGE_KEY, value);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  return [token, setToken];
+}
+
+function handleAuthResponse(response: AuthResponse, setToken: (token: string | null) => void, setUser: (user: User | null) => void) {
+  setToken(response.token);
+  setUser(response.user);
+}
+
+export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [token, setToken] = usePersistedToken();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadProfile = async () => {
+      if (!token) {
+        setUser(null);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const { user: profile } = await fetchProfile(token);
+        if (active) {
+          setUser(profile);
+        }
+      } catch (error) {
+        if (active) {
+          setToken(null);
+          setUser(null);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadProfile();
+
+    return () => {
+      active = false;
+    };
+  }, [token, setToken]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      setLoading(true);
+      try {
+        const response = await loginUser({ email, password });
+        handleAuthResponse(response, setToken, setUser);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [setToken, setUser],
+  );
+
+  const register = useCallback(
+    async (name: string, email: string, password: string) => {
+      setLoading(true);
+      try {
+        const response = await registerUser({ name, email, password });
+        handleAuthResponse(response, setToken, setUser);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [setToken, setUser],
+  );
+
+  const logout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+  }, [setToken]);
+
+  const refreshProfile = useCallback(async () => {
+    if (!token) {
+      setUser(null);
+      return;
+    }
+    const { user: profile } = await fetchProfile(token);
+    setUser(profile);
+  }, [token, setUser]);
+
+  const value = useMemo(
+    () => ({ token, user, loading, login, register, logout, refreshProfile }),
+    [token, user, loading, login, register, logout, refreshProfile],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+import { AuthProvider } from './context/AuthContext';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { fetchUsers } from '../api';
+import { useAuth } from '../context/AuthContext';
+import type { User } from '../types';
+
+const DashboardPage: React.FC = () => {
+  const { token, user } = useAuth();
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadUsers = async () => {
+      if (!token) {
+        setUsers([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      try {
+        const { users: list } = await fetchUsers(token);
+        if (active) {
+          setUsers(list);
+        }
+      } catch (err) {
+        if (active) {
+          const message = err instanceof Error ? err.message : 'Failed to load users';
+          setError(message);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadUsers();
+
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <div>
+          <h2>User dashboard</h2>
+          <p>Welcome back, {user?.name ?? 'friend'}.</p>
+        </div>
+      </div>
+
+      {loading && <p>Loading users...</p>}
+      {error && <p className="error">{error}</p>}
+
+      {!loading && !error && (
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Created</th>
+                <th>Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((item) => (
+                <tr key={item.id}>
+                  <td>{item.id}</td>
+                  <td>{item.name}</td>
+                  <td>{item.email}</td>
+                  <td>{new Date(item.createdAt).toLocaleString()}</td>
+                  <td>{new Date(item.updatedAt).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import type { Location } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const LoginPage: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const from = (location.state as { from?: Location } | undefined)?.from?.pathname ?? '/dashboard';
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await login(email, password);
+      navigate(from, { replace: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to login';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="auth-card">
+      <h2>Sign in</h2>
+      <form onSubmit={handleSubmit} className="form">
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          required
+          autoComplete="email"
+        />
+
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+          autoComplete="current-password"
+        />
+
+        {error && <p className="error">{error}</p>}
+
+        <button type="submit" className="primary" disabled={submitting}>
+          {submitting ? 'Signing in...' : 'Sign in'}
+        </button>
+      </form>
+      <p className="switch-link">
+        New here? <Link to="/register">Create an account</Link>
+      </p>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { updateUser } from '../api';
+import { useAuth } from '../context/AuthContext';
+
+const ProfilePage: React.FC = () => {
+  const { user, token, refreshProfile } = useAuth();
+  const [name, setName] = useState(user?.name ?? '');
+  const [email, setEmail] = useState(user?.email ?? '');
+  const [password, setPassword] = useState('');
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setName(user?.name ?? '');
+    setEmail(user?.email ?? '');
+  }, [user]);
+
+  if (!user || !token) {
+    return <p>Loading profile...</p>;
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setStatus(null);
+    setError(null);
+
+    try {
+      const payload: { name?: string; email?: string; password?: string } = {};
+      if (name !== user.name) {
+        payload.name = name;
+      }
+      if (email !== user.email) {
+        payload.email = email;
+      }
+      if (password) {
+        payload.password = password;
+      }
+
+      if (Object.keys(payload).length === 0) {
+        setStatus('No changes to update');
+        return;
+      }
+
+      await updateUser(token, user.id, payload);
+      await refreshProfile();
+      setPassword('');
+      setStatus('Profile updated successfully');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update profile';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h2>Your profile</h2>
+      <form onSubmit={handleSubmit} className="form">
+        <label htmlFor="name">Name</label>
+        <input id="name" value={name} onChange={(event) => setName(event.target.value)} required />
+
+        <label htmlFor="email">Email</label>
+        <input id="email" type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
+
+        <label htmlFor="password">New password</label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          placeholder="Leave blank to keep current password"
+          minLength={6}
+        />
+
+        {status && <p className="success">{status}</p>}
+        {error && <p className="error">{error}</p>}
+
+        <button type="submit" className="primary" disabled={submitting}>
+          {submitting ? 'Saving...' : 'Save changes'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const RegisterPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { register } = useAuth();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await register(name, email, password);
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to register';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="auth-card">
+      <h2>Create an account</h2>
+      <form onSubmit={handleSubmit} className="form">
+        <label htmlFor="name">Name</label>
+        <input
+          id="name"
+          type="text"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          required
+          autoComplete="name"
+        />
+
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          required
+          autoComplete="email"
+        />
+
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+          minLength={6}
+          autoComplete="new-password"
+        />
+
+        {error && <p className="error">{error}</p>}
+
+        <button type="submit" className="primary" disabled={submitting}>
+          {submitting ? 'Creating account...' : 'Register'}
+        </button>
+      </form>
+      <p className="switch-link">
+        Already have an account? <Link to="/login">Sign in</Link>
+      </p>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,183 @@
+:root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #1f2933;
+  background-color: #f7fafc;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  background-color: #f7fafc;
+}
+
+a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.app-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  background: #1f2937;
+  color: #f9fafb;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+}
+
+.top-bar nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: inherit;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
+.user-chip {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem 1rem;
+}
+
+.card,
+.auth-card {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+  width: min(600px, 100%);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #1d4ed8;
+  color: #fff;
+}
+
+td,
+th {
+  padding: 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+}
+
+input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+button.primary {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+button.primary:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+button.primary:not(:disabled):hover {
+  background: #1d4ed8;
+}
+
+.error {
+  color: #dc2626;
+  margin: 0;
+}
+
+.success {
+  color: #16a34a;
+  margin: 0;
+}
+
+.switch-link {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.centered {
+  padding: 2rem;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .content {
+    padding: 1.5rem 1rem;
+  }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,12 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuthResponse {
+  user: User;
+  token: string;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- implement a Go HTTP API with JWT authentication, SHA-256 password hashing, and user CRUD handlers
- add in-memory user store and middleware to protect protected routes
- scaffold a React + TypeScript frontend with authentication context, login/register forms, and dashboard/profile views

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68df425c6ba483319dc5182e284237e1